### PR TITLE
Add advanced technical indicators

### DIFF
--- a/notebooks/Feature Engineering/02_fixed_features.ipynb
+++ b/notebooks/Feature Engineering/02_fixed_features.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Fixed Features\n",
-    "This notebook demonstrates computing several technical indicators such as Stochastic Oscillator, Williams %R, MACD, Bollinger Bands (%b and bandwidth), ADX, CCI and On-Balance Volume along with other momentum and volatility features."
+    "This notebook demonstrates computing several technical indicators including Stochastic Oscillator, Williams %R, MACD, Price Rate of Change, Bollinger Bands, ADX, CCI, OBV and other momentum and volatility measures.\n"
    ]
   },
   {
@@ -16,23 +16,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "import pandas as pd\n",
     "from src.features.technical_indicators import compute_technical_indicators\n",
     "from src.features.additional_features import compute_additional_features\n",
     "\n",
-    "df = pd.read_parquet(\"../../data/06data.parquet\")\n",
-    "\n",
+    "df = pd.read_parquet('../../data/06data.parquet')\n",
     "df = compute_technical_indicators(df)\n",
     "df = compute_additional_features(df)\n",
     "\n",
-    "cols = ['stoch_k','williams_r','macd','macd_signal','proc',\n",
-    "        'bollinger_b','bollinger_bw','adx','cci','obv']\n",
-    "print(df[cols].head())\n"
+    "cols = [\n",
+    "    'stoch_k','williams_r','macd','macd_signal','proc',\n",
+    "    'bollinger_b','bollinger_bw','adx','cci','obv',\n",
+    "    'vol_zscore_14','momentum_3bar','momentum_6bar',\n",
+    "    'vol_std_3bar','vol_std_7bar','holder_growth_7d',\n",
+    "    'new_addr_growth_7d','tvl_change_7d'\n",
+    "]\n",
+    "df[cols].head()\n"
    ]
   }
-],
-"metadata": {},
-"nbformat": 4,
+ ],
+ "metadata": {},
+ "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/Feature Engineering/02_fixed_features.ipynb
+++ b/notebooks/Feature Engineering/02_fixed_features.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f704bc7e",
+   "metadata": {},
+   "source": [
+    "## Fixed Features\n",
+    "This notebook demonstrates computing several technical indicators such as Stochastic Oscillator, Williams %R, MACD, Bollinger Bands (%b and bandwidth), ADX, CCI and On-Balance Volume along with other momentum and volatility features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27efbdb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import pandas as pd\n",
+    "from src.features.technical_indicators import compute_technical_indicators\n",
+    "from src.features.additional_features import compute_additional_features\n",
+    "\n",
+    "df = pd.read_parquet(\"../../data/06data.parquet\")\n",
+    "\n",
+    "df = compute_technical_indicators(df)\n",
+    "df = compute_additional_features(df)\n",
+    "\n",
+    "cols = ['stoch_k','williams_r','macd','macd_signal','proc',\n",
+    "        'bollinger_b','bollinger_bw','adx','cci','obv']\n",
+    "print(df[cols].head())\n"
+   ]
+  }
+],
+"metadata": {},
+"nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ solana>=0.27           # solana-py RPC client
 python-dotenv>=1.0
 
 hmmlearn>=0.2
+pyarrow>=15.0
+nbformat>=5.10

--- a/src/features/technical_indicators.py
+++ b/src/features/technical_indicators.py
@@ -3,15 +3,33 @@ import numpy as np
 
 
 def compute_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
-    """Compute a suite of technical indicators.
+"""Compute a suite of technical indicators.
 
-    Added columns include common momentum and volatility measures such as the
-    Stochastic Oscillator, Williams %R, MACD and its signal line, Price Rate of
-    Change, short-horizon momentum and volatility metrics.  Additional trend
-    strength and volume features like Bollinger %b, Bollinger bandwidth, ADX,
-    CCI and On-Balance Volume are also provided along with network activity
-    growth metrics.
-    """
+This helper generates a range of indicators used in the forecasting
+notebooks.  The following columns are added (when the required inputs are
+present):
+
+* ``stoch_k`` – Stochastic Oscillator %K calculated from 14‑period highs/lows.
+* ``williams_r`` – Williams %R using the same 14‑period window.
+* ``macd`` / ``macd_signal`` – 12–26 EMA difference and its 9‑period signal
+  line.
+* ``proc`` – price rate of change.
+* ``bollinger_b`` / ``bollinger_bw`` – Bollinger %b and band width from a
+  20‑period moving average.
+* ``adx`` – Average Directional Index measuring trend strength.
+* ``cci`` – Commodity Channel Index.
+* ``obv`` – On‑Balance Volume.
+* ``vol_zscore_14`` – volume Z‑score over a 14‑bar lookback.
+* ``momentum_3bar`` / ``momentum_6bar`` – short‑term returns.
+* ``vol_std_3bar`` / ``vol_std_7bar`` – realised volatility of log returns.
+* ``holder_growth_7d`` / ``new_addr_growth_7d`` – one‑week growth in holders
+  and new addresses.
+* ``tvl_change_7d`` – weekly percentage change in TVL.
+
+The function is tolerant of slightly different input column names (e.g.
+``token_close_usd`` vs ``close_usd``) and operates independently on each token
+in the DataFrame.
+"""
     df = df.copy()
 
     # Ensure timestamp sorted within each token

--- a/src/features/technical_indicators.py
+++ b/src/features/technical_indicators.py
@@ -1,0 +1,111 @@
+import pandas as pd
+import numpy as np
+
+
+def compute_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute a suite of technical indicators.
+
+    Added columns include common momentum and volatility measures such as the
+    Stochastic Oscillator, Williams %R, MACD and its signal line, Price Rate of
+    Change, short-horizon momentum and volatility metrics.  Additional trend
+    strength and volume features like Bollinger %b, Bollinger bandwidth, ADX,
+    CCI and On-Balance Volume are also provided along with network activity
+    growth metrics.
+    """
+    df = df.copy()
+
+    # Ensure timestamp sorted within each token
+    df = df.sort_values(["token", "timestamp"])
+
+    high_col = "high_usd" if "high_usd" in df.columns else "token_high_usd"
+    low_col = "low_usd" if "low_usd" in df.columns else "token_low_usd"
+    close_col = "close_usd" if "close_usd" in df.columns else "token_close_usd"
+    vol_col = "volume_usd" if "volume_usd" in df.columns else "token_volume_usd"
+
+    high = df.groupby("token")[high_col]
+    low = df.groupby("token")[low_col]
+    close = df.groupby("token")[close_col]
+
+    # 14-period highs/lows for Stochastic Oscillator and Williams %R
+    highest_14 = high.transform(lambda x: x.rolling(window=14).max())
+    lowest_14 = low.transform(lambda x: x.rolling(window=14).min())
+
+    stoch_k = 100 * (df[close_col] - lowest_14) / (highest_14 - lowest_14)
+    df['stoch_k'] = stoch_k
+
+    williams_r = -100 * (highest_14 - df[close_col]) / (highest_14 - lowest_14)
+    df['williams_r'] = williams_r
+
+    # MACD using closing price
+    ema12 = close.transform(lambda x: x.ewm(span=12, adjust=False).mean())
+    ema26 = close.transform(lambda x: x.ewm(span=26, adjust=False).mean())
+    macd = ema12 - ema26
+    df['macd'] = macd
+    df['macd_signal'] = macd.groupby(df['token']).transform(lambda x: x.ewm(span=9, adjust=False).mean())
+
+    # Price Rate of Change (12 periods ~ 6 days)
+    proc = close.transform(lambda x: x.pct_change(periods=12))
+    df['proc'] = proc
+
+    # Bollinger Bands (20-period)
+    ma20 = close.transform(lambda x: x.rolling(window=20).mean())
+    std20 = close.transform(lambda x: x.rolling(window=20).std())
+    upper = ma20 + 2 * std20
+    lower = ma20 - 2 * std20
+    df['bollinger_b'] = (df[close_col] - lower) / (upper - lower)
+    df['bollinger_bw'] = (upper - lower) / ma20
+
+    # Average Directional Index (14-period)
+    up_move = high.diff()
+    down_move = (-low.diff())
+    plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
+    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+    prev_close = close.shift()
+    tr = pd.concat([
+        df[high_col] - df[low_col],
+        (df[high_col] - prev_close).abs(),
+        (df[low_col] - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    atr = tr.groupby(df['token']).transform(lambda x: x.ewm(alpha=1/14, adjust=False).mean())
+    plus_di = 100 * pd.Series(plus_dm, index=df.index).groupby(df['token']).transform(lambda x: x.ewm(alpha=1/14, adjust=False).mean()) / atr
+    minus_di = 100 * pd.Series(minus_dm, index=df.index).groupby(df['token']).transform(lambda x: x.ewm(alpha=1/14, adjust=False).mean()) / atr
+    dx = (abs(plus_di - minus_di) / (plus_di + minus_di)) * 100
+    df['adx'] = dx.groupby(df['token']).transform(lambda x: x.ewm(alpha=1/14, adjust=False).mean())
+
+    # Commodity Channel Index (20-period)
+    tp = (df[high_col] + df[low_col] + df[close_col]) / 3
+    tp_ma = tp.groupby(df['token']).transform(lambda x: x.rolling(window=20).mean())
+    mad = tp.groupby(df['token']).transform(lambda x: x.rolling(window=20).apply(lambda y: np.mean(np.abs(y - y.mean())), raw=False))
+    df['cci'] = (tp - tp_ma) / (0.015 * mad)
+
+    # On-Balance Volume
+    price_change_sign = np.sign(df[close_col] - prev_close).fillna(0)
+    df['obv'] = (price_change_sign * df[vol_col]).groupby(df['token']).cumsum()
+
+    # Volume Z-score over 14 bars
+    vol = df.groupby('token')[vol_col]
+    vol_mean = vol.transform(lambda x: x.rolling(window=14).mean())
+    vol_std = vol.transform(lambda x: x.rolling(window=14).std())
+    df['vol_zscore_14'] = (df[vol_col] - vol_mean) / vol_std
+
+    # Short-term momentum (returns)
+    df['momentum_3bar'] = close.transform(lambda x: x.pct_change(periods=3))
+    df['momentum_6bar'] = close.transform(lambda x: x.pct_change(periods=6))
+
+    # Lagged volatility (standard deviation of log returns)
+    logret = close.transform(lambda x: np.log(x) - np.log(x.shift(1)))
+    df['vol_std_3bar'] = logret.groupby(df['token']).transform(lambda x: x.rolling(window=3).std())
+    df['vol_std_7bar'] = logret.groupby(df['token']).transform(lambda x: x.rolling(window=7).std())
+
+    # Network activity growth metrics
+    holders = df.groupby('token')['holder_count']
+    df['holder_growth_7d'] = holders.transform(lambda x: x.pct_change(periods=14))
+
+    new_addr = df.groupby('token')['new_token_accounts']
+    df['new_addr_growth_7d'] = new_addr.transform(lambda x: x.pct_change(periods=14))
+
+    tvl_col = "tvl_usd" if "tvl_usd" in df.columns else "tvl_tvl_usd"
+    tvl = df.groupby("token")[tvl_col]
+    df["tvl_change_7d"] = tvl.transform(lambda x: x.pct_change(periods=14))
+
+    return df


### PR DESCRIPTION
## Summary
- extend `compute_technical_indicators` with Bollinger Bands, ADX, CCI and OBV
- generalise column names to handle different data sets
- update feature engineering notebook to showcase new indicators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859290923f0832eae6785587df0f621