### PR TITLE
Fix tvl_change_7d reference

### DIFF
--- a/notebooks/Feature Engineering/02_fixed_features.ipynb
+++ b/notebooks/Feature Engineering/02_fixed_features.ipynb
@@ -1327,9 +1327,7 @@
     "    new_addr = df.groupby('token')['new_token_accounts']\n",
     "    df['new_addr_growth_7d'] = new_addr.transform(lambda x: x.pct_change(periods=14))\n",
     "\n",
-    "    tvl_col = \"tvl_usd\" if \"tvl_usd\" in df.columns else \"tvl_tvl_usd\"\n",
-    "    tvl = df.groupby(\"token\")[tvl_col]\n",
-    "    df[\"tvl_change_7d\"] = tvl.transform(lambda x: x.pct_change(periods=14))\n",
+    "    df['tvl_change_7d'] = df.groupby('token')['tvl_usd'].transform(lambda x: x.pct_change(periods=14))\n",
     "\n",
     "    return df"
    ]


### PR DESCRIPTION
## Summary
- use `tvl_usd` directly in technical indicator generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685936ab8aac832ea2500c3d42101a7b